### PR TITLE
fix/ci linux only stable

### DIFF
--- a/.ci/preflight.zsh
+++ b/.ci/preflight.zsh
@@ -1,0 +1,16 @@
+#!/usr/bin/env zsh
+mkdir -p "$PWD/.logs"
+LOG="$PWD/.logs/preflight.log"; : > "$LOG"
+r() { print -r -- "\n$ $*" | tee -a "$LOG"; eval "$*" 2>&1 | tee -a "$LOG"; }
+python3 -m venv .venv && . .venv/bin/activate
+r "python -m pip install -U pip wheel build"
+r "pip install -U ruff black mypy pytest"
+r "pip install -e ."
+r "ruff check ."
+r "ruff format --check ."
+r "black --check ."
+r "pytest -q"
+r "mypy ."
+r "python -m build"
+deactivate
+print -r -- "\nLog completo: $LOG"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: '3.11' }
-      - run: python -m pip install -U pip
-      - run: pip install -U ruff black mypy pytest build
-      - run: pip install -e .
+        with:
+          python-version: "3.11"
       - run: : > ci.log
+      - run: echo '$ python -m pip install -U pip' | tee -a ci.log
+      - run: python -m pip install -U pip 2>&1 | tee -a ci.log
+      - run: echo '$ pip install -U ruff black mypy pytest build' | tee -a ci.log
+      - run: pip install -U ruff black mypy pytest build 2>&1 | tee -a ci.log
+      - run: echo '$ pip install -e .' | tee -a ci.log
+      - run: pip install -e . 2>&1 | tee -a ci.log
       - run: echo '$ ruff check .' | tee -a ci.log
       - run: ruff check . 2>&1 | tee -a ci.log
       - run: echo '$ ruff format --check .' | tee -a ci.log
@@ -37,10 +41,13 @@ jobs:
           subprocess.check_call([sys.executable,"-m","pip","install",ws[0]])
           import header_guardian as m; print("import OK", getattr(m,"__version__","?"))
           PY
-      - name: Upload job log
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with: { name: ci-log-py311, path: ci.log, if-no-files-found: warn, retention-days: 7 }
+        with:
+          name: ci-log-py311
+          path: ci.log
+          if-no-files-found: warn
+          retention-days: 7
 
   linux-py312:
     name: python-3.12 on ubuntu-latest
@@ -48,11 +55,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: '3.12' }
-      - run: python -m pip install -U pip
-      - run: pip install -U ruff black mypy pytest build
-      - run: pip install -e .
+        with:
+          python-version: "3.12"
       - run: : > ci.log
+      - run: echo '$ python -m pip install -U pip' | tee -a ci.log
+      - run: python -m pip install -U pip 2>&1 | tee -a ci.log
+      - run: echo '$ pip install -U ruff black mypy pytest build' | tee -a ci.log
+      - run: pip install -U ruff black mypy pytest build 2>&1 | tee -a ci.log
+      - run: echo '$ pip install -e .' | tee -a ci.log
+      - run: pip install -e . 2>&1 | tee -a ci.log
       - run: echo '$ ruff check .' | tee -a ci.log
       - run: ruff check . 2>&1 | tee -a ci.log
       - run: echo '$ ruff format --check .' | tee -a ci.log
@@ -74,7 +85,10 @@ jobs:
           subprocess.check_call([sys.executable,"-m","pip","install",ws[0]])
           import header_guardian as m; print("import OK", getattr(m,"__version__","?"))
           PY
-      - name: Upload job log
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with: { name: ci-log-py312, path: ci.log, if-no-files-found: warn, retention-days: 7 }
+        with:
+          name: ci-log-py312
+          path: ci.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: CI
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   linux-py311:
@@ -17,13 +18,32 @@ jobs:
       - run: python -m pip install -U pip
       - run: pip install -U ruff black mypy pytest build
       - run: pip install -e .
-      - run: ruff check .
-      - run: ruff format --check .
-      - run: black --check .
-      - run: pytest -q
-      - run: mypy .
+      - name: Init log
+        run: : > ci.log
+      - name: Ruff check
+        run: |
+          echo '$ ruff check .' | tee -a ci.log
+          ruff check . 2>&1 | tee -a ci.log
+      - name: Ruff format --check
+        run: |
+          echo '$ ruff format --check .' | tee -a ci.log
+          ruff format --check . 2>&1 | tee -a ci.log
+      - name: Black --check
+        run: |
+          echo '$ black --check .' | tee -a ci.log
+          black --check . 2>&1 | tee -a ci.log
+      - name: Pytest
+        run: |
+          echo '$ pytest -q' | tee -a ci.log
+          pytest -q 2>&1 | tee -a ci.log
+      - name: Mypy
+        run: |
+          echo '$ mypy .' | tee -a ci.log
+          mypy . 2>&1 | tee -a ci.log
       - name: Build wheel
-        run: python -m build
+        run: |
+          echo '$ python -m build' | tee -a ci.log
+          python -m build 2>&1 | tee -a ci.log
       - name: Install built wheel & smoke
         run: |
           python - <<'PY'
@@ -33,6 +53,14 @@ jobs:
           subprocess.check_call([sys.executable,"-m","pip","install",ws[0]])
           import header_guardian as m; print("import OK", getattr(m,"__version__","?"))
           PY
+      - name: Upload job log
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-log-py311
+          path: ci.log
+          if-no-files-found: warn
+          retention-days: 7
 
   linux-py312:
     name: python-3.12 on ubuntu-latest
@@ -44,13 +72,32 @@ jobs:
       - run: python -m pip install -U pip
       - run: pip install -U ruff black mypy pytest build
       - run: pip install -e .
-      - run: ruff check .
-      - run: ruff format --check .
-      - run: black --check .
-      - run: pytest -q
-      - run: mypy .
+      - name: Init log
+        run: : > ci.log
+      - name: Ruff check
+        run: |
+          echo '$ ruff check .' | tee -a ci.log
+          ruff check . 2>&1 | tee -a ci.log
+      - name: Ruff format --check
+        run: |
+          echo '$ ruff format --check .' | tee -a ci.log
+          ruff format --check . 2>&1 | tee -a ci.log
+      - name: Black --check
+        run: |
+          echo '$ black --check .' | tee -a ci.log
+          black --check . 2>&1 | tee -a ci.log
+      - name: Pytest
+        run: |
+          echo '$ pytest -q' | tee -a ci.log
+          pytest -q 2>&1 | tee -a ci.log
+      - name: Mypy
+        run: |
+          echo '$ mypy .' | tee -a ci.log
+          mypy . 2>&1 | tee -a ci.log
       - name: Build wheel
-        run: python -m build
+        run: |
+          echo '$ python -m build' | tee -a ci.log
+          python -m build 2>&1 | tee -a ci.log
       - name: Install built wheel & smoke
         run: |
           python - <<'PY'
@@ -60,3 +107,11 @@ jobs:
           subprocess.check_call([sys.executable,"-m","pip","install",ws[0]])
           import header_guardian as m; print("import OK", getattr(m,"__version__","?"))
           PY
+      - name: Upload job log
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-log-py312
+          path: ci.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 on:
   push:
+    branches: [ main, "fix/**" ]
   pull_request:
   workflow_dispatch:
 
@@ -11,8 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+        with: { python-version: "3.11" }
       - run: : > ci.log
       - run: echo '$ python -m pip install -U pip' | tee -a ci.log
       - run: python -m pip install -U pip 2>&1 | tee -a ci.log
@@ -43,11 +43,7 @@ jobs:
           PY
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
-        with:
-          name: ci-log-py311
-          path: ci.log
-          if-no-files-found: warn
-          retention-days: 7
+        with: { name: ci-log-py311, path: ci.log, if-no-files-found: error, retention-days: 7 }
 
   linux-py312:
     name: python-3.12 on ubuntu-latest
@@ -55,8 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
+        with: { python-version: "3.12" }
       - run: : > ci.log
       - run: echo '$ python -m pip install -U pip' | tee -a ci.log
       - run: python -m pip install -U pip 2>&1 | tee -a ci.log
@@ -87,8 +82,4 @@ jobs:
           PY
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
-        with:
-          name: ci-log-py312
-          path: ci.log
-          if-no-files-found: warn
-          retention-days: 7
+        with: { name: ci-log-py312, path: ci.log, if-no-files-found: error, retention-days: 7 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,39 +1,55 @@
 name: CI
-
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main]
   workflow_dispatch:
-
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
-  python-3.11 on ubuntu-latest:
+  linux:
+    name: python-${{ matrix.py }} on ubuntu-latest
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        py: ["3.11","3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with: { python-version: ${{ matrix.py }} }
+      - uses: actions/cache@v4
         with:
-          python-version: '3.11'
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ matrix.py }}-${{ hashFiles('pyproject.toml') }}
       - run: python -m pip install -U pip
-      - run: python -m pip install ruff black pytest mypy build
       - run: python -m pip install .
-      - run: python -m ruff check .
-      - run: python -m black --check .
+      - run: python -m pip install ruff==0.6.9 black==24.10.0 pytest==8.4.2 mypy==1.17.1
+      - run: ruff check .
+      - run: black --check .
+      - run: ruff format --check .
       - run: pytest -q
       - run: mypy .
-
-  python-3.12 on ubuntu-latest:
-    runs-on: ubuntu-latest
+  windows:
+    name: python-${{ matrix.py }} on windows-latest
+    runs-on: windows-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        py: ["3.11","3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
+        with: { python-version: ${{ matrix.py }} }
       - run: python -m pip install -U pip
-      - run: python -m pip install ruff black pytest mypy build
       - run: python -m pip install .
-      - run: python -m ruff check .
-      - run: python -m black --check .
+      - run: python -m pip install ruff==0.6.9 black==24.10.0 pytest==8.4.2 mypy==1.17.1
+      - run: ruff check .
+      - run: black --check .
+      - run: ruff format --check .
       - run: pytest -q
       - run: mypy .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,9 @@
 name: CI
 on:
   push:
+    branches: ['**']
   pull_request:
   workflow_dispatch:
-
-permissions:
-  contents: read
 
 jobs:
   linux-py311:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,59 +1,22 @@
 name: CI
 on:
   push:
-    branches: [ main, fix/ci-linux-only-stable ]
   pull_request:
   workflow_dispatch:
 
-permissions: { contents: read }
+permissions:
+  contents: read
 
 jobs:
-  linux-py311:
-    name: python-3.11 on ubuntu-latest
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with: { python-version: '3.11' }
-      - run: : > ci.log
-      - run: echo '$ python -m pip install -U pip' | tee -a ci.log
-      - run: python -m pip install -U pip 2>&1 | tee -a ci.log
-      - run: echo '$ pip install -U ruff black mypy pytest build' | tee -a ci.log
-      - run: pip install -U ruff black mypy pytest build 2>&1 | tee -a ci.log
-      - run: echo '$ pip install -e .' | tee -a ci.log
-      - run: pip install -e . 2>&1 | tee -a ci.log
-      - run: echo '$ ruff check .' | tee -a ci.log
-      - run: ruff check . 2>&1 | tee -a ci.log
-      - run: echo '$ ruff format --check .' | tee -a ci.log
-      - run: ruff format --check . 2>&1 | tee -a ci.log
-      - run: echo '$ black --check .' | tee -a ci.log
-      - run: black --check . 2>&1 | tee -a ci.log
-      - run: echo '$ pytest -q' | tee -a ci.log
-      - run: pytest -q 2>&1 | tee -a ci.log
-      - run: echo '$ mypy .' | tee -a ci.log
-      - run: mypy . 2>&1 | tee -a ci.log
-      - run: echo '$ python -m build' | tee -a ci.log
-      - run: python -m build 2>&1 | tee -a ci.log
-      - name: Install built wheel & smoke
-        run: |
-          python - <<'PY'
-          import glob, subprocess, sys
-          ws = glob.glob("dist/*.whl"); assert ws, "wheel not built"
-          subprocess.check_call([sys.executable,"-m","pip","install","-U","pip"])
-          subprocess.check_call([sys.executable,"-m","pip","install",ws[0]])
-          import header_guardian as m; print("import OK", getattr(m,"__version__","?"))
-          PY
-      - uses: actions/upload-artifact@v4
-        if: ${{ always() }}
-        with: { name: ci-log-py311, path: ci.log, if-no-files-found: warn, retention-days: 7 }
-
   linux-py312:
     name: python-3.12 on ubuntu-latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: '3.12' }
+        with:
+          python-version: "3.12"
+
       - run: : > ci.log
       - run: echo '$ python -m pip install -U pip' | tee -a ci.log
       - run: python -m pip install -U pip 2>&1 | tee -a ci.log
@@ -73,15 +36,21 @@ jobs:
       - run: mypy . 2>&1 | tee -a ci.log
       - run: echo '$ python -m build' | tee -a ci.log
       - run: python -m build 2>&1 | tee -a ci.log
-      - name: Install built wheel & smoke
+
+      - name: Smoke import wheel
         run: |
           python - <<'PY'
           import glob, subprocess, sys
           ws = glob.glob("dist/*.whl"); assert ws, "wheel not built"
-          subprocess.check_call([sys.executable,"-m","pip","install","-U","pip"])
           subprocess.check_call([sys.executable,"-m","pip","install",ws[0]])
           import header_guardian as m; print("import OK", getattr(m,"__version__","?"))
           PY
-      - uses: actions/upload-artifact@v4
+
+      - name: Upload job log
         if: ${{ always() }}
-        with: { name: ci-log-py312, path: ci.log, if-no-files-found: warn, retention-days: 7 }
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-log-py312
+          path: ci.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,11 @@
 name: CI
 on:
   push:
-    branches: [ main, "fix/**" ]
+    branches: [ main, fix/ci-linux-only-stable ]
   pull_request:
   workflow_dispatch:
+
+permissions: { contents: read }
 
 jobs:
   linux-py311:
@@ -12,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: "3.11" }
+        with: { python-version: '3.11' }
       - run: : > ci.log
       - run: echo '$ python -m pip install -U pip' | tee -a ci.log
       - run: python -m pip install -U pip 2>&1 | tee -a ci.log
@@ -43,7 +45,7 @@ jobs:
           PY
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
-        with: { name: ci-log-py311, path: ci.log, if-no-files-found: error, retention-days: 7 }
+        with: { name: ci-log-py311, path: ci.log, if-no-files-found: warn, retention-days: 7 }
 
   linux-py312:
     name: python-3.12 on ubuntu-latest
@@ -51,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: "3.12" }
+        with: { python-version: '3.12' }
       - run: : > ci.log
       - run: echo '$ python -m pip install -U pip' | tee -a ci.log
       - run: python -m pip install -U pip 2>&1 | tee -a ci.log
@@ -82,4 +84,4 @@ jobs:
           PY
       - uses: actions/upload-artifact@v4
         if: ${{ always() }}
-        with: { name: ci-log-py312, path: ci.log, if-no-files-found: error, retention-days: 7 }
+        with: { name: ci-log-py312, path: ci.log, if-no-files-found: warn, retention-days: 7 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,32 +15,19 @@ jobs:
       - run: python -m pip install -U pip
       - run: pip install -U ruff black mypy pytest build
       - run: pip install -e .
-      - name: Init log
-        run: : > ci.log
-      - name: Ruff check
-        run: |
-          echo '$ ruff check .' | tee -a ci.log
-          ruff check . 2>&1 | tee -a ci.log
-      - name: Ruff format --check
-        run: |
-          echo '$ ruff format --check .' | tee -a ci.log
-          ruff format --check . 2>&1 | tee -a ci.log
-      - name: Black --check
-        run: |
-          echo '$ black --check .' | tee -a ci.log
-          black --check . 2>&1 | tee -a ci.log
-      - name: Pytest
-        run: |
-          echo '$ pytest -q' | tee -a ci.log
-          pytest -q 2>&1 | tee -a ci.log
-      - name: Mypy
-        run: |
-          echo '$ mypy .' | tee -a ci.log
-          mypy . 2>&1 | tee -a ci.log
-      - name: Build wheel
-        run: |
-          echo '$ python -m build' | tee -a ci.log
-          python -m build 2>&1 | tee -a ci.log
+      - run: : > ci.log
+      - run: echo '$ ruff check .' | tee -a ci.log
+      - run: ruff check . 2>&1 | tee -a ci.log
+      - run: echo '$ ruff format --check .' | tee -a ci.log
+      - run: ruff format --check . 2>&1 | tee -a ci.log
+      - run: echo '$ black --check .' | tee -a ci.log
+      - run: black --check . 2>&1 | tee -a ci.log
+      - run: echo '$ pytest -q' | tee -a ci.log
+      - run: pytest -q 2>&1 | tee -a ci.log
+      - run: echo '$ mypy .' | tee -a ci.log
+      - run: mypy . 2>&1 | tee -a ci.log
+      - run: echo '$ python -m build' | tee -a ci.log
+      - run: python -m build 2>&1 | tee -a ci.log
       - name: Install built wheel & smoke
         run: |
           python - <<'PY'
@@ -53,11 +40,7 @@ jobs:
       - name: Upload job log
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
-        with:
-          name: ci-log-py311
-          path: ci.log
-          if-no-files-found: warn
-          retention-days: 7
+        with: { name: ci-log-py311, path: ci.log, if-no-files-found: warn, retention-days: 7 }
 
   linux-py312:
     name: python-3.12 on ubuntu-latest
@@ -69,32 +52,19 @@ jobs:
       - run: python -m pip install -U pip
       - run: pip install -U ruff black mypy pytest build
       - run: pip install -e .
-      - name: Init log
-        run: : > ci.log
-      - name: Ruff check
-        run: |
-          echo '$ ruff check .' | tee -a ci.log
-          ruff check . 2>&1 | tee -a ci.log
-      - name: Ruff format --check
-        run: |
-          echo '$ ruff format --check .' | tee -a ci.log
-          ruff format --check . 2>&1 | tee -a ci.log
-      - name: Black --check
-        run: |
-          echo '$ black --check .' | tee -a ci.log
-          black --check . 2>&1 | tee -a ci.log
-      - name: Pytest
-        run: |
-          echo '$ pytest -q' | tee -a ci.log
-          pytest -q 2>&1 | tee -a ci.log
-      - name: Mypy
-        run: |
-          echo '$ mypy .' | tee -a ci.log
-          mypy . 2>&1 | tee -a ci.log
-      - name: Build wheel
-        run: |
-          echo '$ python -m build' | tee -a ci.log
-          python -m build 2>&1 | tee -a ci.log
+      - run: : > ci.log
+      - run: echo '$ ruff check .' | tee -a ci.log
+      - run: ruff check . 2>&1 | tee -a ci.log
+      - run: echo '$ ruff format --check .' | tee -a ci.log
+      - run: ruff format --check . 2>&1 | tee -a ci.log
+      - run: echo '$ black --check .' | tee -a ci.log
+      - run: black --check . 2>&1 | tee -a ci.log
+      - run: echo '$ pytest -q' | tee -a ci.log
+      - run: pytest -q 2>&1 | tee -a ci.log
+      - run: echo '$ mypy .' | tee -a ci.log
+      - run: mypy . 2>&1 | tee -a ci.log
+      - run: echo '$ python -m build' | tee -a ci.log
+      - run: python -m build 2>&1 | tee -a ci.log
       - name: Install built wheel & smoke
         run: |
           python - <<'PY'
@@ -107,8 +77,4 @@ jobs:
       - name: Upload job log
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
-        with:
-          name: ci-log-py312
-          path: ci.log
-          if-no-files-found: warn
-          retention-days: 7
+        with: { name: ci-log-py312, path: ci.log, if-no-files-found: warn, retention-days: 7 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,55 +1,65 @@
 name: CI
+
 on:
-  push: { branches: [ main ] }
+  push:
+    branches: [ main ]
   pull_request:
+    branches: [ main ]
   workflow_dispatch:
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
-permissions: { contents: read }
 
 jobs:
-  linux:
-    name: python-${{ matrix.py }} on ubuntu-latest
+  python-3-11-ubuntu:
+    name: python-3.11 on ubuntu-latest
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix: { py: ["3.11","3.12"] }
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: ${{ matrix.py }} }
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: pip-${{ runner.os }}-${{ matrix.py }}-${{ hashFiles('pyproject.toml') }}
-      - run: python -m pip install -U pip build
-      - run: python -m build
-      - run: python -m pip install dist/*.whl
-      - run: python -m pip install ruff==0.6.9 black==24.10.0 pytest==8.4.2 mypy==1.17.1
+        with: { python-version: '3.11' }
+      - run: python -m pip install -U pip wheel build
+      - run: pip install -U ruff black mypy pytest
+      - run: pip install -e .
       - run: ruff check .
-      - run: black --check .
       - run: ruff format --check .
+      - run: black --check .
       - run: pytest -q
       - run: mypy .
+      - name: Build wheel
+        run: python -m build
+      - name: Install built wheel & smoke
+        run: |
+          echo "WHEEL_PATH=$(python - <<'PY'
+import glob; ws=glob.glob("dist/*.whl"); print(ws[0] if ws else "")
+PY
+          )" >> $GITHUB_ENV
+          python -m pip install "${WHEEL_PATH}"
+          python - <<'PY'
+import header_guardian as m; print("import OK", getattr(m,"__version__","?"))
+PY
 
-  windows:
-    name: python-${{ matrix.py }} on windows-latest
-    runs-on: windows-latest
-    continue-on-error: true
-    strategy:
-      fail-fast: false
-      matrix: { py: ["3.11","3.12"] }
+  python-3-12-ubuntu:
+    name: python-3.12 on ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: ${{ matrix.py }} }
-      - run: python -m pip install -U pip build
-      - run: python -m build
-      - run: python -m pip install dist/*.whl
-      - run: python -m pip install ruff==0.6.9 black==24.10.0 pytest==8.4.2 mypy==1.17.1
+        with: { python-version: '3.12' }
+      - run: python -m pip install -U pip wheel build
+      - run: pip install -U ruff black mypy pytest
+      - run: pip install -e .
       - run: ruff check .
-      - run: black --check .
       - run: ruff format --check .
+      - run: black --check .
       - run: pytest -q
       - run: mypy .
+      - name: Build wheel
+        run: python -m build
+      - name: Install built wheel & smoke
+        run: |
+          echo "WHEEL_PATH=$(python - <<'PY'
+import glob; ws=glob.glob("dist/*.whl"); print(ws[0] if ws else "")
+PY
+          )" >> $GITHUB_ENV
+          python -m pip install "${WHEEL_PATH}"
+          python - <<'PY'
+import header_guardian as m; print("import OK", getattr(m,"__version__","?"))
+PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,14 @@
 name: CI
 on:
-  push: { branches: [main] }
-  pull_request: { branches: [main] }
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
-  python-3.11 on ubuntu-latest:
+  linux-py311:
+    name: python-3.11 on ubuntu-latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,7 +16,7 @@ jobs:
         with: { python-version: '3.11' }
       - run: python -m pip install -U pip
       - run: pip install -U ruff black mypy pytest build
-      - run: pip install .
+      - run: pip install -e .
       - run: ruff check .
       - run: ruff format --check .
       - run: black --check .
@@ -27,14 +27,15 @@ jobs:
       - name: Install built wheel & smoke
         run: |
           python - <<'PY'
-          import glob,subprocess,sys
-          ws=glob.glob("dist/*.whl"); assert ws, "wheel not built"
-          subprocess.run([sys.executable,"-m","pip","install","-U","pip"], check=True)
-          subprocess.run([sys.executable,"-m","pip","install",ws[0]], check=True)
+          import glob, subprocess, sys
+          ws = glob.glob("dist/*.whl"); assert ws, "wheel not built"
+          subprocess.check_call([sys.executable,"-m","pip","install","-U","pip"])
+          subprocess.check_call([sys.executable,"-m","pip","install",ws[0]])
           import header_guardian as m; print("import OK", getattr(m,"__version__","?"))
           PY
 
-  python-3.12 on ubuntu-latest:
+  linux-py312:
+    name: python-3.12 on ubuntu-latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +43,7 @@ jobs:
         with: { python-version: '3.12' }
       - run: python -m pip install -U pip
       - run: pip install -U ruff black mypy pytest build
-      - run: pip install .
+      - run: pip install -e .
       - run: ruff check .
       - run: ruff format --check .
       - run: black --check .
@@ -53,9 +54,9 @@ jobs:
       - name: Install built wheel & smoke
         run: |
           python - <<'PY'
-          import glob,subprocess,sys
-          ws=glob.glob("dist/*.whl"); assert ws, "wheel not built"
-          subprocess.run([sys.executable,"-m","pip","install","-U","pip"], check=True)
-          subprocess.run([sys.executable,"-m","pip","install",ws[0]], check=True)
+          import glob, subprocess, sys
+          ws = glob.glob("dist/*.whl"); assert ws, "wheel not built"
+          subprocess.check_call([sys.executable,"-m","pip","install","-U","pip"])
+          subprocess.check_call([sys.executable,"-m","pip","install",ws[0]])
           import header_guardian as m; print("import OK", getattr(m,"__version__","?"))
           PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+
 on:
   push:
   pull_request:
@@ -10,33 +11,36 @@ permissions:
 
 jobs:
   linux-py312:
-    name: python-3.12 on ubuntu-latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: '3.12'
 
-      - run: : > ci.log
-      - run: echo '$ python -m pip install -U pip' | tee -a ci.log
-      - run: python -m pip install -U pip 2>&1 | tee -a ci.log
-      - run: echo '$ pip install -U ruff black mypy pytest build' | tee -a ci.log
-      - run: pip install -U ruff black mypy pytest build 2>&1 | tee -a ci.log
-      - run: echo '$ pip install -e .' | tee -a ci.log
-      - run: pip install -e . 2>&1 | tee -a ci.log
-      - run: echo '$ ruff check .' | tee -a ci.log
-      - run: ruff check . 2>&1 | tee -a ci.log
-      - run: echo '$ ruff format --check .' | tee -a ci.log
-      - run: ruff format --check . 2>&1 | tee -a ci.log
-      - run: echo '$ black --check .' | tee -a ci.log
-      - run: black --check . 2>&1 | tee -a ci.log
-      - run: echo '$ pytest -q' | tee -a ci.log
-      - run: pytest -q 2>&1 | tee -a ci.log
-      - run: echo '$ mypy .' | tee -a ci.log
-      - run: mypy . 2>&1 | tee -a ci.log
-      - run: echo '$ python -m build' | tee -a ci.log
-      - run: python -m build 2>&1 | tee -a ci.log
+      - name: Preinstall
+        run: |
+          python -m pip install -U pip
+          pip install -U ruff black mypy pytest build
+
+      - name: Install editable
+        run: pip install -e .
+
+      - name: Run checks (log único)
+        run: |
+          : > ci.log
+          echo '$ ruff check .' | tee -a ci.log
+          ruff check . 2>&1 | tee -a ci.log
+          echo '$ ruff format --check .' | tee -a ci.log
+          ruff format --check . 2>&1 | tee -a ci.log
+          echo '$ black --check .' | tee -a ci.log
+          black --check . 2>&1 | tee -a ci.log
+          echo '$ pytest -q' | tee -a ci.log
+          pytest -q 2>&1 | tee -a ci.log
+          echo '$ mypy .' | tee -a ci.log
+          mypy . 2>&1 | tee -a ci.log
+          echo '$ python -m build' | tee -a ci.log
+          python -m build 2>&1 | tee -a ci.log
 
       - name: Smoke import wheel
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,20 @@
 name: CI
 on:
-  push:
-    branches: [ main ]
+  push: { branches: [ main ] }
   pull_request:
   workflow_dispatch:
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
-permissions:
-  contents: read
+permissions: { contents: read }
+
 jobs:
   linux:
     name: python-${{ matrix.py }} on ubuntu-latest
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        py: ["3.11","3.12"]
+      matrix: { py: ["3.11","3.12"] }
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -25,28 +23,30 @@ jobs:
         with:
           path: ~/.cache/pip
           key: pip-${{ runner.os }}-${{ matrix.py }}-${{ hashFiles('pyproject.toml') }}
-      - run: python -m pip install -U pip
-      - run: python -m pip install .
+      - run: python -m pip install -U pip build
+      - run: python -m build
+      - run: python -m pip install dist/*.whl
       - run: python -m pip install ruff==0.6.9 black==24.10.0 pytest==8.4.2 mypy==1.17.1
       - run: ruff check .
       - run: black --check .
       - run: ruff format --check .
       - run: pytest -q
       - run: mypy .
+
   windows:
     name: python-${{ matrix.py }} on windows-latest
     runs-on: windows-latest
     continue-on-error: true
     strategy:
       fail-fast: false
-      matrix:
-        py: ["3.11","3.12"]
+      matrix: { py: ["3.11","3.12"] }
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with: { python-version: ${{ matrix.py }} }
-      - run: python -m pip install -U pip
-      - run: python -m pip install .
+      - run: python -m pip install -U pip build
+      - run: python -m build
+      - run: python -m pip install dist/*.whl
       - run: python -m pip install ruff==0.6.9 black==24.10.0 pytest==8.4.2 mypy==1.17.1
       - run: ruff check .
       - run: black --check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,65 +1,44 @@
 name: CI
-
 on:
   push:
-    branches: [ main ]
+    branches: [ main, '**' ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:
 
 jobs:
-  python-3-11-ubuntu:
-    name: python-3.11 on ubuntu-latest
+  test:
+    name: python-${{ matrix.python-version }} on ubuntu-latest
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11','3.12']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
-        with: { python-version: '3.11' }
-      - run: python -m pip install -U pip wheel build
-      - run: pip install -U ruff black mypy pytest
-      - run: pip install -e .
-      - run: ruff check .
-      - run: ruff format --check .
-      - run: black --check .
-      - run: pytest -q
-      - run: mypy .
-      - name: Build wheel
-        run: python -m build
-      - name: Install built wheel & smoke
-        run: |
-          echo "WHEEL_PATH=$(python - <<'PY'
-import glob; ws=glob.glob("dist/*.whl"); print(ws[0] if ws else "")
-PY
-          )" >> $GITHUB_ENV
-          python -m pip install "${WHEEL_PATH}"
-          python - <<'PY'
-import header_guardian as m; print("import OK", getattr(m,"__version__","?"))
-PY
+        with: { python-version: ${{ matrix.python-version }} }
 
-  python-3-12-ubuntu:
-    name: python-3.12 on ubuntu-latest
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with: { python-version: '3.12' }
       - run: python -m pip install -U pip wheel build
       - run: pip install -U ruff black mypy pytest
       - run: pip install -e .
+
       - run: ruff check .
       - run: ruff format --check .
       - run: black --check .
       - run: pytest -q
       - run: mypy .
+
       - name: Build wheel
         run: python -m build
+
       - name: Install built wheel & smoke
         run: |
-          echo "WHEEL_PATH=$(python - <<'PY'
-import glob; ws=glob.glob("dist/*.whl"); print(ws[0] if ws else "")
-PY
-          )" >> $GITHUB_ENV
-          python -m pip install "${WHEEL_PATH}"
           python - <<'PY'
-import header_guardian as m; print("import OK", getattr(m,"__version__","?"))
-PY
+          import glob, subprocess, sys
+          ws = glob.glob("dist/*.whl")
+          assert ws, "wheel not built"
+          subprocess.run([sys.executable,"-m","pip","install","-U","pip"], check=True)
+          subprocess.run([sys.executable,"-m","pip","install",ws[0]], check=True)
+          import header_guardian as m; print("import OK", getattr(m,"__version__","?"))
+          PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,43 +1,60 @@
 name: CI
 on:
-  push:
-    branches: [ main, '**' ]
-  pull_request:
-    branches: [ main ]
+  push: { branches: [main] }
+  pull_request: { branches: [main] }
   workflow_dispatch:
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  test:
-    name: python-${{ matrix.python-version }} on ubuntu-latest
+  python-3.11 on ubuntu-latest:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.11','3.12']
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: ${{ matrix.python-version }} }
-
-      - run: python -m pip install -U pip wheel build
-      - run: pip install -U ruff black mypy pytest
-      - run: pip install -e .
-
+        with: { python-version: '3.11' }
+      - run: python -m pip install -U pip
+      - run: pip install -U ruff black mypy pytest build
+      - run: pip install .
       - run: ruff check .
       - run: ruff format --check .
       - run: black --check .
       - run: pytest -q
       - run: mypy .
-
       - name: Build wheel
         run: python -m build
-
       - name: Install built wheel & smoke
         run: |
           python - <<'PY'
-          import glob, subprocess, sys
-          ws = glob.glob("dist/*.whl")
-          assert ws, "wheel not built"
+          import glob,subprocess,sys
+          ws=glob.glob("dist/*.whl"); assert ws, "wheel not built"
+          subprocess.run([sys.executable,"-m","pip","install","-U","pip"], check=True)
+          subprocess.run([sys.executable,"-m","pip","install",ws[0]], check=True)
+          import header_guardian as m; print("import OK", getattr(m,"__version__","?"))
+          PY
+
+  python-3.12 on ubuntu-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - run: python -m pip install -U pip
+      - run: pip install -U ruff black mypy pytest build
+      - run: pip install .
+      - run: ruff check .
+      - run: ruff format --check .
+      - run: black --check .
+      - run: pytest -q
+      - run: mypy .
+      - name: Build wheel
+        run: python -m build
+      - name: Install built wheel & smoke
+        run: |
+          python - <<'PY'
+          import glob,subprocess,sys
+          ws=glob.glob("dist/*.whl"); assert ws, "wheel not built"
           subprocess.run([sys.executable,"-m","pip","install","-U","pip"], check=True)
           subprocess.run([sys.executable,"-m","pip","install",ws[0]], check=True)
           import header_guardian as m; print("import OK", getattr(m,"__version__","?"))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,52 +1,39 @@
 name: CI
+
 on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: read
-
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
-  linux:
-    name: python-${{ matrix.python-version }} on ubuntu-latest
+  python-3.11 on ubuntu-latest:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11","3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.11'
       - run: python -m pip install -U pip
-      - run: pip install ruff black pytest mypy
-      - run: ruff check .
-      - run: black --check .
-      - run: ruff format --check .
+      - run: python -m pip install ruff black pytest mypy build
+      - run: python -m pip install .
+      - run: python -m ruff check .
+      - run: python -m black --check .
       - run: pytest -q
       - run: mypy .
 
-  windows_optional:
-    name: python-3.12 on windows-latest
-    runs-on: windows-latest
-    continue-on-error: true
+  python-3.12 on ubuntu-latest:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: '3.12'
       - run: python -m pip install -U pip
-      - run: pip install ruff black pytest mypy
-      - run: ruff check .
-      - run: black --check .
-      - run: ruff format --check .
+      - run: python -m pip install ruff black pytest mypy build
+      - run: python -m pip install .
+      - run: python -m ruff check .
+      - run: python -m black --check .
       - run: pytest -q
       - run: mypy .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   linux-py312:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 on:
   push:
-    branches: ['**']
   pull_request:
   workflow_dispatch:
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 __pycache__/
 .mypy_cache/
 .pytest_cache/
+.logs/

--- a/src/header_guardian/core.py
+++ b/src/header_guardian/core.py
@@ -83,7 +83,8 @@ def ensure_header(path: Path, header: str, *, autofix: bool = False) -> bool:
     text = path.read_text(encoding="utf-8", errors="ignore")
     # Evita duplicados si corre en paralelo
     if not has_header(path, header):
-        path.write_text(f"{header}{'' if header.endswith('\n') else '\n'}{text}", encoding="utf-8")
+        suffix = \"\" if header.endswith(\"\n\") else \"\n\"
+        path.write_text(f\"{header}{suffix}{text}\", encoding=\"utf-8\")
     return True
 
 

--- a/src/header_guardian/core.py
+++ b/src/header_guardian/core.py
@@ -83,8 +83,8 @@ def ensure_header(path: Path, header: str, *, autofix: bool = False) -> bool:
     text = path.read_text(encoding="utf-8", errors="ignore")
     # Evita duplicados si corre en paralelo
     if not has_header(path, header):
-        suffix = \"\" if header.endswith(\"\n\") else \"\n\"
-        path.write_text(f\"{header}{suffix}{text}\", encoding=\"utf-8\")
+        suffix = "" if header.endswith("\n") else "\n"
+        path.write_text(f"{header}{suffix}{text}", encoding="utf-8")
     return True
 
 


### PR DESCRIPTION
- **ci: stable pip CI; exact linux job names; align required checks**
- **ci: stable pip CI; linux jobs required; windows optional (continue-on-error)**
- **ci: build wheel with 'python -m build' and install it; linux required, windows optional**
- **ci: make CI linux-only and stable; robust wheel install (no globs)**
